### PR TITLE
 Fix: Use `File::create` instead of `File::create_new` in `Articles::save`

### DIFF
--- a/api/src/articles.rs
+++ b/api/src/articles.rs
@@ -126,7 +126,7 @@ mod _fs {
         }
 
         pub fn save(&self, path: impl AsRef<Path>) -> io::Result<()> {
-            let file = File::create_new(path)?;
+            let file = File::create(path)?;
             let writer = StrictWriter::with(StreamWriter::new::<U24MAX>(file));
             self.encode(writer)
         }


### PR DESCRIPTION
## Issue Description

In the RGB protocol implementation, when a wallet receives a transfer, the `accept_transfer -> consume_from_file` method fails with a "Merge" error due to an incorrect file creation method. This occurs because in `sonic/api/src/articles.rs`, the `Articles::save` method uses `File::create_new()`, which requires that the file must not exist. When the receiver attempts to merge and store articles files that already exist, it causes an IO error, which then triggers a Merge error.

## Steps to Reproduce

1. Create two wallet instances
2. Issue RGB assets in the first wallet
3. Send the contract to the second wallet
4. Generate a receiving invoice in the second wallet
5. Transfer assets from the first wallet to the second wallet
6. The second wallet fails when trying to accept the transfer

Error log( example from `rgb-tests`):
```
thread 'simple_transfer::case_1' panicked at tests/transfer.rs:82:49:
called `Result::unwrap()` on an `Err` value: "consume_from_file error: Merge(..)"
```

## Root Cause

When executing `wlt_2.accept_transfer -> consume_from_file`, it needs to merge Articles and save them internally. The `Articles::save` method uses `File::create_new()`, which returns an error if the file already exists. In the transfer scenario, the articles file needs to be updated rather than created a new, so `File::create()` should be used instead.

## Fix

Replace in `sonic/api/src/articles.rs`:
```rust
let file = File::create_new(path)?;
```

With:
```rust
let file = File::create(path)?;
```

This allows overwriting existing files, solving the Merge error problem when receiving transfers. 