### PR TITLE
Fix: Prevent duplicate operations in rollback chain

### DIFF
--- a/src/ledger.rs
+++ b/src/ledger.rs
@@ -336,15 +336,17 @@ impl<S: Stock> Ledger<S> {
         // Get all subsequent operations
         loop {
             let mut count = 0usize;
-            for mut index in 0..chain.len() {
+            for index in 0..chain.len() {
                 let opid = chain[index];
                 let op = self.0.operation(opid);
                 for no in 0..op.destructible.len_u16() {
                     let addr = CellAddr::new(opid, no);
                     let Some(spent) = self.0.spent_by(addr) else { continue };
+                    if chain.contains(&spent) {
+                        continue;
+                    }
                     chain.push_front(spent);
                     count += 1;
-                    index += 1;
                 }
             }
             if count == 0 {


### PR DESCRIPTION
## Problem

While testing RGB v0.12, I discovered an issue in the `rollback` function in `src/ledger.rs`. The function was collecting operations for rollback based on dependency relationships, but under certain conditions it would add duplicate operations to the chain.

Debug logs showed the problem clearly:
```
[sonic/src/ledger.rs:336:9] &chain = [
    Opid(Array<32>(76a58a4c9aa30d989065f578f04c5f2b971fe88ab43552525c92fbc7dff75353)),
]

[sonic/src/ledger.rs:354:17] &chain = [
    Opid(Array<32>(e885994f3c8d0d50d91220ad36c7219560bbb1aad26b8e0b3ee6fa5f931a9b0e)),
    // ... repeated 19 more times ...
    Opid(Array<32>(3608751cea1d2d751ae528db20b7fa4f7bca34e0496548d98862571e9786033f)),
    Opid(Array<32>(76a58a4c9aa30d989065f578f04c5f2b971fe88ab43552525c92fbc7dff75353)),
]
```

As you can see, the initial chain contained a single operation ID, but after several iterations, it grew to 22 elements with 20 duplicates of the same operation.

This occurred because:
1. The code lacked duplicate detection
2. The `index += 1` adjustment was unnecessary and problematic since the for-loop already increments the index naturally, and the loop range `0..chain.len()` is determined before each iteration, so manually incrementing the index could cause elements to be skipped
3. The nested loop structure repeatedly processed the same operations

## Solution

Fixed the issue with two simple but effective changes:
1. Added a duplicate check before adding an operation to the chain
2. Removed the incorrect index adjustment (`index += 1`)

```rust
// Before:
let Some(spent) = self.0.spent_by(addr) else { continue };
chain.push_front(spent);
count += 1;
index += 1;  // This was problematic

// After:
let Some(spent) = self.0.spent_by(addr) else { continue };
if chain.contains(&spent) {
    continue;
}
chain.push_front(spent);
count += 1;
// index += 1 removed
```

## Impact

This fix ensures that:
- The rollback function properly handles operation dependencies without duplicates
- The operation chain remains at a reasonable size
- No infinite loops or exponential growth issues
- Correct ordering of operations is maintained for rollback